### PR TITLE
Issue 3 get temp directory from config file

### DIFF
--- a/statline_bq/cli.py
+++ b/statline_bq/cli.py
@@ -22,9 +22,13 @@ def upload_datasets():
 
     config_path = Path("./config.toml")
     config = utils.parse_config_toml(config_path)
-    click.echo("The following datasets will be downloaded from CBS and uploaded:")
+    click.echo("The following datasets will be downloaded from CBS and uploaded into:")
+    click.echo("")
+    click.echo(f"Project: {config.gcp.project}")
+    click.echo(f"Bucket:  {config.gcp.bucket}")
+    click.echo("")
+    for i, dataset in enumerate(config.datasets):
+        click.echo(f"{i+1}. {dataset}")
+    click.echo("")
     for dataset in config.datasets:
-        click.echo(f"{dataset}")
-    for dataset in config.datasets:
-        utils.cbs_odata_to_gcs(dataset, gcp=config.gcp)
-    # click.echo(dataset)
+        utils.cbs_odata_to_gcs(id=dataset, config=config)

--- a/statline_bq/config.toml
+++ b/statline_bq/config.toml
@@ -1,13 +1,21 @@
 [gcp]
+# Google cloud project parameters are defined here
 project = "dataverbinders-dev"
 bucket = "dataverbinders-dev_test"
 # location = "EU"  # currently not used/implemented
 # credentials = "" # currently not taken here. User needs to have authentication setup previous to using this library.
                    # see "https://cloud.google.com/docs/authentication/end-user" for instructions if issues occur with authentication.
 
-
 [datasets]
+# Datasets to download from CBS and upload to GCP are defined here
 datasets = [
     "83583NED",
     "83765NED"
     ]
+
+[paths]
+# Temporary paths to use for transformations are defined here.
+# All data paths are relative to "Path.home()/root"
+root = "Projects/statline-bq"
+temp = "temp"
+# cbs = "cbs"


### PR DESCRIPTION
I have added the paths part to the `config.toml` file, its parsing into a named tuple in `utils.parse_config_toml`, and I am now sending the entire `config` object in the main function call.

I am not entirely satisfied with this implementation, mainly for 2 reasons (second reason more than the first):
1. in `cli.py`, after parsing the config file, it makes sense to send the whole object. However, that object also contains a list of all the datasets' ids, whereas each time we only handle a single one, so that seems like the wrong way to go about it.
2. The `utils.parse_config_toml` is a tailored solution. I address each part in the toml file specifically, and if we would to add another part to it, this function should be updated as well. The reason for this, is that after generically parsing the whole file into a dict using `toml.load()`, the conversion to nested tuples and named tuples is quite elaborate.

If you have 2 cents here, I'm happy to hear. It works as is, right now, and I'm not sure if to invest more in it.