### PR TITLE
Lazy processing of datasets

### DIFF
--- a/statline_bq/cli.py
+++ b/statline_bq/cli.py
@@ -13,9 +13,14 @@ from statline_bq.config import get_config, get_datasets
     default="dev",
     help='Which gcp configuration to use - can take either "dev", "test" or "prod".',
 )
+@click.option(
+    "--force/--no-force",
+    default=False,
+    help="A flag that forces dataset processing even if the dataset's 'last_modified' metadata field is the same as the same dataset's metadata previously processesed.",
+)
 # @click.argument("config", type=click.File("r"))
 # @click.argument("dataset")
-def upload_datasets(gcp_env: str):
+def upload_datasets(gcp_env: str, force: bool):
     """
     This CLI uploads datasets from CBS to Google Cloud Platform.
 
@@ -50,5 +55,5 @@ def upload_datasets(gcp_env: str):
         click.echo(f"{i+1}. {dataset}")
     click.echo("")
     for id in datasets:
-        main(id=id, config=config, gcp_env=gcp_env)
+        main(id=id, config=config, gcp_env=gcp_env, force=force)
     click.echo("Finished processing datasets.")


### PR DESCRIPTION
First PR for 2021 :)
____
This PR adds the functionality of checking whether an identical version of the to-be-processed dataset already exists in GCP, and skips the whole process if it does.

To check identity, the `"Modified"` field of the dataset metadata is used:
  * In v3, the metadata table is called `"TableInfos"`
  * In v4, the metadata table is called `"Properties"`
_________
The following logic is implemented:
1. The source metadata is retrieved from cbs
2. The GCP metadata is retrieved (if possible - otherwise, is set to `None`)
3. The `"Modified"` field is extracted from both.
4. If they are identical, the process is skipped, and the following dataset is attempted.
5. The process now includes writing a metadata `dict` into a json file and uploading it to the appropriate folder in GCS (later to be retrieved to check the next time against the source).
6. A new parameter `force` is introduced, which allows force processing, by skipping this check (it can be set to True if using the CLI by typing `statline-bq --force`
______
Other points:
1. Reading the `"Description"` field from the metadata was already implemented. It was written into a .txt file, uploaded to GCS and read when linking GCS to BQ. This is now changed to a more generic process (as partly described above): On upload - getting the whole metadata table, writing it as json file and uploading it GCS. On link to BQ - reading the json as a dict, extracting the required elements (currently `"Description"` and `"Modified"`), and using as needed.
2. The current implementation does not automatically handle any processes stopped halfway through. Meaning, if I have already uploaded the files to GCS, and then stopped the process before linking in BQ, the dataset will be skipped, unless `--force` is used. Theoretically, I would like to add the `"Modified"` field somewhere in BQ as well, and separate these checks. I thought of using BQ labels for this. TODO.
3. Similar to previous point, on a finer granularity level issues could occur if only part of the files were upload to GCS or linked to BQ. Not sure if worth addressing, as this might be handled for us through Prefect.
4. I have also added a function to get the latest upload (we've discussed this before) - `get_latest_folder()`, and is is used when retrieving the metadata.
_____
This is the first (and largest) step in this [`nl-open-data` issue](https://github.com/dataverbinders/nl-open-data/issues/38).