### PR TITLE
add odata_version handling for iv3

### DIFF
--- a/statline_bq/config.py
+++ b/statline_bq/config.py
@@ -72,8 +72,6 @@ class Paths:
 
     Attributes
     ----------
-    root: str
-        The path leading to the local folder of 'statline-bq'
     temp: str
         A folder to usewhen writing to disk temporarly
     agb: str
@@ -84,14 +82,20 @@ class Paths:
         A folder to hold all cbs related data
     bag: str
         A folder to hold all bag related data
+    mlz: str
+        A folder to hold all mlz related data
+    rivm: str
+        A folder to hold all rivm related data
     """
 
-    root: str = None
+    # root: str = None
     temp: str = None
     agb: str = None
     vektis_open_data: str = None
     cbs: str = None
     bag: str = None
+    mlz: str = None
+    rivm: str = None
 
 
 @deserialize

--- a/statline_bq/config.toml
+++ b/statline_bq/config.toml
@@ -22,6 +22,11 @@
     
 [paths]
 # Temporary paths to use for transformations are defined here.
-# All data paths are relative to "Path(__file__).parent"
+
+# temp folder is relative to "Path(__file__).parent"
 temp = "temp"
+
+# All other folders are nested inder temp
 cbs = "cbs"
+mlz = "mlz"
+rivm = "rivm"

--- a/statline_bq/utils.py
+++ b/statline_bq/utils.py
@@ -61,6 +61,10 @@ def check_v4(id: str, third_party: bool = False) -> str:
         "v4" if exists as odata v4, "v3" otherwise.
     """
 
+    # Third party ("dataderden..cbs.nl") do not have v4 implemenetd
+    if third_party:
+        return "v3"
+
     base_url = {
         True: None,  # currently no IV3 links in ODATA V4,
         False: f"https://odata4.cbs.nl/CBS/{id}",
@@ -670,7 +674,7 @@ def convert_table_to_parquet(
 
     # create directories to store files
     out_dir = Path(out_dir)
-    temp_json_dir = Path(f"temp/json/{file_name}")
+    temp_json_dir = out_dir.parent / Path(f"json/{file_name}")
     create_dir(temp_json_dir)
     create_dir(out_dir)
 
@@ -1595,8 +1599,16 @@ if __name__ == "__main__":
     from statline_bq.config import get_config
 
     config = get_config("./statline_bq/config.toml")
-    main("83583NED", config=config, gcp_env="dev", force=True)
+    # main("83583NED", config=config, gcp_env="dev", force=True)
     # main("83765NED", config=config, gcp_env="dev")
+    main(
+        "40060NED",
+        source="mlz",
+        third_party=True,
+        config=config,
+        gcp_env="dev",
+        force=False,
+    )
 
 # from statline_bq.config import get_config
 


### PR DESCRIPTION
@dkapitan 
It seems all IV3 datasets are "v3", although I could not find anywhere where that is officially stated.

At this point, I simply assign `odata_version = "v3"` automatically if `thirs_party==True`. When the sources start using v4, we will decide how to implement.

Alos, worth note - any `source` input (i.e. `source="cbs"` or `source="mlz"`) must be configured in 2 places:
under `config.py`, a placeholder for `config.paths.{source_name}`, and inside `config.toml` - the user-defined folder. Meaning every time a new source is added, these 2 must be updated, or an error is raised. I don't consider it an issue, but worth mentioning.
