### PR TITLE
add credentials parameter to all gcp-related utils

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "statline-bq"
-version = "0.1.1"
+version = "0.1.2"
 description = "Library to upload CBS open datasets into Google Cloud Platform"
 authors = ["Daniel Kapitan <daniel@kapitan.net>", "Amit Gal <amitgalmail@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Add option to supply `credentials` to all GCP related interactions (i.e. `bigquery.client.create_dataset`).

This is in order to allow use of imported library with a service account from a VM.