### PR TITLE
Add prod envs

### DIFF
--- a/statline_bq/config.py
+++ b/statline_bq/config.py
@@ -32,7 +32,16 @@ class GcpProject:
 @serialize
 @dataclass(frozen=True)
 class GcpProductionProjects:
-    """????
+    """An object holding all different production GcpProjects.
+
+    Attributes
+    ----------
+    cbs_dl: GcpProject
+        A GcpProject instance for a CBS Datalake.
+    external_dl: GcpProject
+        A GcpProject instance for an external (=non CBS) Datalake.
+    dwh: GcpProject
+        A GcpProject instance to be for a datawarehouse.
 
     """
 
@@ -54,8 +63,8 @@ class Gcp:
         A GcpProject instance to be used for development.
     test: GcpProject
         A GcpProject instance to be used for testing.
-    prod: GcpProject
-        A GcpProject instance to be used for production.
+    prod: GcpProductionProjects
+        A GcpProductionProjects instance, holding various GcpProjects for production.
     """
 
     dev: GcpProject

--- a/statline_bq/config.py
+++ b/statline_bq/config.py
@@ -31,6 +31,19 @@ class GcpProject:
 @deserialize
 @serialize
 @dataclass(frozen=True)
+class GcpProductionProjects:
+    """????
+
+    """
+
+    cbs_dl: GcpProject
+    external_dl: GcpProject
+    dwh: GcpProject
+
+
+@deserialize
+@serialize
+@dataclass(frozen=True)
 class Gcp:
     """An immutable Data Class for Google Cloud Platform, holding three
     GCPProject, one per development stage: 'dev', 'test' and 'prod'.
@@ -47,7 +60,7 @@ class Gcp:
 
     dev: GcpProject
     test: GcpProject
-    prod: GcpProject
+    prod: GcpProductionProjects
 
 
 @deserialize

--- a/statline_bq/config.py
+++ b/statline_bq/config.py
@@ -32,7 +32,7 @@ class GcpProject:
 @serialize
 @dataclass(frozen=True)
 class GcpProductionProjects:
-    """An object holding all different production GcpProjects.
+    """An object holding all possible production GcpProjects.
 
     Attributes
     ----------

--- a/statline_bq/config.toml
+++ b/statline_bq/config.toml
@@ -1,24 +1,29 @@
 [gcp]
     [gcp.prod]
-    project_id = "dataverbinders"
-    bucket = "dataverbinders"
-    location = "EU"
-    # credentials = ""  # currently not taken here. User needs to have authentication setup previous to using this library.
-                        # see "https://cloud.google.com/docs/authentication/end-user" for instructions if issues occur with authentication.
+        [gcp.prod.cbs_dl]
+        project_id = "dataverbinders-cbs-dl"
+        bucket = "dataverbinders-cbs-dl"
+        location = "EU"
+
+        [gcp.prod.external_dl]
+        project_id = "dataverbinders-external-dl"
+        bucket = "dataverbinders-external-dl"
+        location = "EU"
+
+        [gcp.prod.dwh]
+        project_id = "dataverbinders-open-dwh"
+        bucket = "dataverbinders-open-dwh"  # No bucket exists - not needed currently.
+        location = "EU"
 
     [gcp.test]
     project_id = "dataverbinders-test"
     bucket = "dataverbinders-test"
     location = "EU"
-    # credentials = ""  # currently not taken here. User needs to have authentication setup previous to using this library.
-                        # see "https://cloud.google.com/docs/authentication/end-user" for instructions if issues occur with authentication.
 
     [gcp.dev]
     project_id = "dataverbinders-dev"
     bucket = "dataverbinders-dev"
     location = "EU"
-    # credentials = ""  # currently not taken here. User needs to have authentication setup previous to using this library.
-                        # see "https://cloud.google.com/docs/authentication/end-user" for instructions if issues occur with authentication.
     
 [paths]
 # Temporary folders are defined here.

--- a/statline_bq/utils.py
+++ b/statline_bq/utils.py
@@ -678,8 +678,9 @@ def upload_to_gcs(
     source: str = "cbs",
     odata_version: str = None,
     id: str = None,
-    config: Config = None,
-    gcp_env: str = None,
+    gcp: GcpProject = None,
+    # config: Config = None,
+    # gcp_env: str = None,
     credentials: Credentials = None,
 ) -> str:  # TODO change the return value to some indication or id from Google?:
     """Uploads all files in a given directory to Google Cloud Storage.
@@ -718,7 +719,7 @@ def upload_to_gcs(
         The folder (=blob) into which the tables have been uploaded # TODO -> Return success/ fail code?/job ID
     """
     # Initialize Google Storage Client and get bucket according to gcp_env
-    gcp = set_gcp(config=config, gcp_env=gcp_env, source=source)
+    # gcp = set_gcp(config=config, gcp_env=gcp_env, source=source)
     gcs = storage.Client(project=gcp.project_id, credentials=credentials)
     gcs_bucket = gcs.get_bucket(gcp.bucket)
     # Set blob
@@ -772,7 +773,7 @@ def get_file_names(paths: Iterable[Union[str, PathLike]]) -> list:
 def bq_update_main_table_col_descriptions(
     dataset_ref: str,
     descriptions: dict,
-    config: Config = None,
+    # config: Config = None,
     gcp: GcpProject = None,
     credentials: Credentials = None,
 ) -> bigquery.Table:
@@ -839,8 +840,9 @@ def get_col_descs_from_gcs(
     id: str,
     source: str = "cbs",
     odata_version: str = None,
-    config: Config = None,
-    gcp_env: str = "dev",
+    gcp: GcpProject = None,
+    # config: Config = None,
+    # gcp_env: str = "dev",
     gcs_folder: str = None,
     credentials: Credentials = None,
 ) -> dict:
@@ -872,7 +874,7 @@ def get_col_descs_from_gcs(
     dict
         Dictionary holding column descriptions
     """
-    gcp = set_gcp(config, gcp_env, source)
+    # gcp = set_gcp(config, gcp_env, source)
     client = storage.Client(project=gcp.project_id, credentials=credentials)
     bucket = client.get_bucket(gcp.bucket)
     blob = bucket.get_blob(
@@ -1080,8 +1082,9 @@ def cbsodata_to_gbq(
         source=source,
         odata_version=odata_version,
         id=id,
-        config=config,
-        gcp_env=gcp_env,
+        gcp=gcp,
+        # config=config,
+        # gcp_env=gcp_env,
         credentials=credentials,
     )
 
@@ -1092,10 +1095,11 @@ def cbsodata_to_gbq(
         id=id,
         source=source,
         odata_version=odata_version,
-        config=config,
+        # config=config,
         gcs_folder=gcs_folder,
         file_names=file_names,
-        gcp_env=gcp_env,
+        # gcp_env=gcp_env,
+        gcp=gcp,
         credentials=credentials,
     )
     # Add column description to main table
@@ -1103,8 +1107,9 @@ def cbsodata_to_gbq(
         id=id,
         source=source,
         odata_version=odata_version,
-        config=config,
-        gcp_env=gcp_env,
+        gcp=gcp,
+        # config=config,
+        # gcp_env=gcp_env,
         gcs_folder=gcs_folder,
         credentials=credentials,
     )
@@ -1112,7 +1117,11 @@ def cbsodata_to_gbq(
     # Add column descriptions to main table (only relevant for v3, as v4 is a "long format")
     if odata_version == "v3":
         bq_update_main_table_col_descriptions(
-            dataset_ref, desc_dict, config, gcp, credentials=credentials
+            dataset_ref=dataset_ref,
+            descriptions=desc_dict,
+            # config=config,
+            gcp=gcp,
+            credentials=credentials,
         )
 
     # Remove all local files for this process
@@ -1543,11 +1552,12 @@ def gcs_to_gbq(
     id: str,
     source: str = "cbs",
     odata_version: str = None,
-    third_party: bool = False,
-    config: Config = None,
+    # third_party: bool = False,
+    # config: Config = None,
     gcs_folder: str = None,
     file_names: list = None,
-    gcp_env: str = None,
+    gcp: GcpProject = None,
+    # gcp_env: str = None,
     credentials: Credentials = None,
 ) -> None:  # TODO Return job id
     """Creates a BQ dataset and links all relevant tables from GCS underneath.
@@ -1598,7 +1608,7 @@ def gcs_to_gbq(
     # ]
 
     # Set GCP Environment
-    gcp = set_gcp(config=config, gcp_env=gcp_env, source=source)
+    # gcp = set_gcp(config=config, gcp_env=gcp_env, source=source)
     # Get metadata
     meta_gcp = get_metadata_gcp(
         id=id,
@@ -1708,7 +1718,7 @@ if __name__ == "__main__":
 
     config = get_config("./statline_bq/config.toml")
     # # Test cbs core dataset, odata_version is v3
-    main("83583NED", config=config, gcp_env="prod", force=False)
+    main("83583NED", config=config, gcp_env="prod", force=True)
     # Test cbs core dataset, odata_version is v4
     # main("83765NED", config=config, gcp_env="dev", force=True)
     # Test IV3 dataset, odata_version is v3

--- a/statline_bq/utils.py
+++ b/statline_bq/utils.py
@@ -679,8 +679,6 @@ def upload_to_gcs(
     odata_version: str = None,
     id: str = None,
     gcp: GcpProject = None,
-    # config: Config = None,
-    # gcp_env: str = None,
     credentials: Credentials = None,
 ) -> str:  # TODO change the return value to some indication or id from Google?:
     """Uploads all files in a given directory to Google Cloud Storage.
@@ -773,7 +771,6 @@ def get_file_names(paths: Iterable[Union[str, PathLike]]) -> list:
 def bq_update_main_table_col_descriptions(
     dataset_ref: str,
     descriptions: dict,
-    # config: Config = None,
     gcp: GcpProject = None,
     credentials: Credentials = None,
 ) -> bigquery.Table:
@@ -841,8 +838,6 @@ def get_col_descs_from_gcs(
     source: str = "cbs",
     odata_version: str = None,
     gcp: GcpProject = None,
-    # config: Config = None,
-    # gcp_env: str = "dev",
     gcs_folder: str = None,
     credentials: Credentials = None,
 ) -> dict:
@@ -1083,8 +1078,6 @@ def cbsodata_to_gbq(
         odata_version=odata_version,
         id=id,
         gcp=gcp,
-        # config=config,
-        # gcp_env=gcp_env,
         credentials=credentials,
     )
 
@@ -1095,10 +1088,8 @@ def cbsodata_to_gbq(
         id=id,
         source=source,
         odata_version=odata_version,
-        # config=config,
         gcs_folder=gcs_folder,
         file_names=file_names,
-        # gcp_env=gcp_env,
         gcp=gcp,
         credentials=credentials,
     )
@@ -1108,8 +1099,6 @@ def cbsodata_to_gbq(
         source=source,
         odata_version=odata_version,
         gcp=gcp,
-        # config=config,
-        # gcp_env=gcp_env,
         gcs_folder=gcs_folder,
         credentials=credentials,
     )
@@ -1119,7 +1108,6 @@ def cbsodata_to_gbq(
         bq_update_main_table_col_descriptions(
             dataset_ref=dataset_ref,
             descriptions=desc_dict,
-            # config=config,
             gcp=gcp,
             credentials=credentials,
         )
@@ -1552,12 +1540,9 @@ def gcs_to_gbq(
     id: str,
     source: str = "cbs",
     odata_version: str = None,
-    # third_party: bool = False,
-    # config: Config = None,
     gcs_folder: str = None,
     file_names: list = None,
     gcp: GcpProject = None,
-    # gcp_env: str = None,
     credentials: Credentials = None,
 ) -> None:  # TODO Return job id
     """Creates a BQ dataset and links all relevant tables from GCS underneath.
@@ -1693,7 +1678,6 @@ def main(
     force: bool = False,
 ) -> None:
     gcp_env = gcp_env.lower()
-    # id = id.upper()
     if check_gcp_env(gcp_env):
         print(f"Processing dataset {id}")
         # print("TEST CHANGES")


### PR DESCRIPTION
@dkapitan 
Implementation of the new project structure in `config.py` and in the `set_gcp()` function.

Additionally, I've previously used `config` and `gcp_env` as parameters for multiple functions, such as `upload_to_gcs`, but have now changed it to taking the actual GcpProject instance, after it's set once by `set_gcp()`.

This is related to #16 - currently I feel this makes more sense.

Let me know what you think.