### PR TITLE
Stream parquet write

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,17 @@ Using Poetry:
 
 There are two elements that need to be configured prior to using the CLI. If using as an imported library the exact usage determines wheteher these are both needed (or just one, or none)
 
-#### 1. GCP and Paths through config.toml
+#### 1. GCP and Paths through `config.toml`
 
-The GCP project id, bucket, and location should be given by editing `statline_bq/config.toml`, allowing uup to 3 choices at runtime: `dev`, `test` and `prod`. Note that you must nest gcp projects details correctly for them to be interperted, as seen below. You must have the proper IAM (permissions) on the GCP projects (more details below).
+##### 1.1. GCP
+The GCP project id, bucket, and location should be provided by editing `statline_bq/config.toml`, allowing up to 3 choices at runtime: `dev`, `test` and `prod`. `prod` is further divided into 3: `cbs_dl` serving as a data lake for the BASE CBS catalog, `external_dl` serving as a data lake for the THIRD-PARTY catalog and `dwh`, meant for any additional or combined resources. The selection within the three `prod` environments is automatically inferred at runtime, according to the `source` parameter.
+
+Note that you must nest gcp projects details correctly for them to be interperted, as seen below. You must also have the proper IAM (permissions) on the GCP projects (more details below).
 
 Correct nesting in config file:
 ```
 [gcp]
-    [gcp.prod]
+    [gcp.dev]
     project_id = "my_dev_project_id"
     bucket = "my_dev_bucket"
     location = "EU"
@@ -42,11 +45,23 @@ Correct nesting in config file:
     location = "EU"
 
     [gcp.prod]
-    project_id = "my_prod_project_id"
-    bucket = "my_prod_bucket"
-    location = "EU"
+        [gcp.prod.cbs_dl]
+        project_id = "my-cbs-dl"
+        bucket = "my-cbs-dl_bucket"
+        location = "EU"
+
+        [gcp.prod.external_dl]
+        project_id = "my-external-dl"
+        bucket = "my-external-dl_bucket"
+        location = "EU"
+
+        [gcp.prod.dwh]
+        project_id = "my-open-dwh"
+        bucket = "my-open-dwh_bucket"
+        location = "EU"
 ```
-Additionally, the local paths used by the library can configured here. Under `[paths]` define the path to the library, and other temporary folders if desired.
+##### 1.2. Paths
+Additionally, the local temp paths used by the library can be configured here. If a new `source` is used, it must be added both in `config.toml` under `[paths]` and in `config.py` to the `Paths` Class.
 
 #### 2. Datasets through `datasets.toml`
 
@@ -61,11 +76,17 @@ This should be given by directly editing `statline_bq/datasets.toml`
 statline-bq can be used via a command line, or imported as a library.
 
 #### CLI
-Once the library is installed and configured:
+Once the library is installed and configured, you can either used `poetry run`:
 
 1. From your terminal, navigate to "my_path_to_library/statline-bq/statline_bq/"
 2. run `poetry run statline-bq`
 3. That's it!
+
+Or spawn a shell:
+
+1. From your terminal, navigate to "my_path_to_library/statline-bq/statline_bq/"
+2. run `poetry shell`
+3. run `statline-bq --help` for info
 
 #### In a python script
 

--- a/statline_bq/config.toml
+++ b/statline_bq/config.toml
@@ -12,7 +12,7 @@
 
         [gcp.prod.dwh]
         project_id = "dataverbinders-open-dwh"
-        bucket = "dataverbinders-open-dwh"  # No bucket exists - not needed currently.
+        bucket = "dataverbinders-open-dwh"
         location = "EU"
 
     [gcp.test]
@@ -39,3 +39,6 @@ iv3 = "iv3"
 mkb = "mkb"
 jm = "jm"
 interreg = "interreg"
+agb = "agb"
+vektis_open_data = "vektis_open_data"
+bag = "bag"

--- a/statline_bq/utils.py
+++ b/statline_bq/utils.py
@@ -176,49 +176,45 @@ def get_schema_cbs(metadata_url) -> pa.Schema:
     metadata_url : [type]
         [description]
     """
-    odata_to_pa_hash = {
-        "Edm.Int32": pa.int32(),
-        "Edm.String": pa.string(),
-        "Edm.Single": pa.float32(),
-    }
     # TODO complete full list
     # odata.types taken from: http://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/part3-csdl/odata-v4.0-errata03-os-part3-csdl-complete.html#Picture 1:~:text=4.4%20Primitive%20Types,-Structured
     # pyarrow types taken from: https://arrow.apache.org/docs/python/api/datatypes.html
-    # odata_to_pa_hash = {
-    #     'Edm.Binary': pa.binary(),
-    #     'Edm.Boolean': pa.bool_(),
-    #     'Edm.Byte': pa.int8(),
-    # #     'Edm.Date': pa.date32(), or pa.date64(), or something else?
-    # #     'Edm.DateTimeOffset': pa.timestamp() #Likely requires some wrangling to match
-    #     'Edm.Decimal':
-    #     'Edm.Double'
-    #     'Edm.Duration'
-    #     'Edm.Guid'
-    #     'Edm.Int16'
-    #     'Edm.Int32'
-    #     'Edm.Int64'
-    #     'Edm.SByte'
-    #     'Edm.Single': pa.float32(),
-    #     'Edm.Stream'
-    #     'Edm.String'
-    #     'Edm.TimeOfDay'
-    #     'Edm.Geography'
-    #     'Edm.GeographyPoint'
-    #     'Edm.GeographyLineString'
-    #     'Edm.GeographyPolygon'
-    #     'Edm.GeographyMultiPoint'
-    #     'Edm.GeographyMultiLineString'
-    #     'Edm.GeographyMultiPolygon'
-    #     'Edm.GeographyCollection'
-    #     'Edm.Geometry'
-    #     'Edm.GeometryPoint'
-    #     'Edm.GeometryLineString'
-    #     'Edm.GeometryPolygon'
-    #     'Edm.GeometryMultiPoint'
-    #     'Edm.GeometryMultiLineString'
-    #     'Edm.GeometryMultiPolygon'
-    #     'Edm.GeometryCollection'
-    # }
+    odata_to_pa_hash = {
+        "Edm.Binary": pa.binary(),
+        "Edm.Boolean": pa.bool_(),
+        "Edm.Byte": pa.int8(),
+        # 'Edm.Date': pa.date32(), or pa.date64(), or something else?
+        # 'Edm.DateTimeOffset': pa.timestamp() #Likely requires some wrangling to match
+        # "Edm.Decimal": pa.decimal128(),  # TODO: Add precision and scale (see facets below)
+        "Edm.Double": pa.float64(),
+        # 'Edm.Duration': #TODO ??
+        # 'Edm.Guid': #TODO ??
+        "Edm.Int16": pa.int16(),
+        "Edm.Int32": pa.int32(),
+        "Edm.Int64": pa.int64(),
+        "Edm.SByte": pa.int8(),
+        "Edm.Single": pa.float32(),
+        # 'Edm.Stream': #TODO ??
+        "Edm.String": pa.string(),
+        # 'Edm.TimeOfDay': #TODO ??
+        # TODO: add geodata translation:
+        # 'Edm.Geography'
+        # 'Edm.GeographyPoint'
+        # 'Edm.GeographyLineString'
+        # 'Edm.GeographyPolygon'
+        # 'Edm.GeographyMultiPoint'
+        # 'Edm.GeographyMultiLineString'
+        # 'Edm.GeographyMultiPolygon'
+        # 'Edm.GeographyCollection'
+        # 'Edm.Geometry'
+        # 'Edm.GeometryPoint'
+        # 'Edm.GeometryLineString'
+        # 'Edm.GeometryPolygon'
+        # 'Edm.GeometryMultiPoint'
+        # 'Edm.GeometryMultiLineString'
+        # 'Edm.GeometryMultiPolygon'
+        # 'Edm.GeometryCollection'
+    }
     r = requests.get(metadata_url)
     root = ET.fromstring(r.content)
     TData = root.find(".//*[@Name='TData']")

--- a/statline_bq/utils.py
+++ b/statline_bq/utils.py
@@ -9,11 +9,10 @@ from tempfile import gettempdir
 import xml.etree.ElementTree as ET
 
 import ndjson
-from dask.bag import Bag as DaskBag
 import dask.bag as db
+import pyarrow as pa
 from pyarrow import json as pa_json
 import pyarrow.parquet as pq
-import pyarrow as pa
 from google.cloud import storage
 from google.cloud import bigquery
 from google.api_core import exceptions

--- a/statline_bq/utils.py
+++ b/statline_bq/utils.py
@@ -530,115 +530,135 @@ def get_column_descriptions_v3(url_data_properties: str) -> dict:
     return col_desc
 
 
-def get_odata(table_urls: list) -> DaskBag:
-    """Create a dask.bag object holding all values of a table for a CBS dataset
+# def get_odata(table_urls: list) -> DaskBag:
+#     """Create a dask.bag object holding all values of a table for a CBS dataset
 
-    This functions maps `load_from_url()` on a list of urls, all related to a single
-    CBS table, from a specific dataset. Since requests to CBS are limited at 10,000
-    rows (=observations/records), the table_urls consists of the same base url, each ending with "$?SKIP={i}",
-    where i is an integer with multiples of 10,000, i.e.:
+#     This functions maps `load_from_url()` on a list of urls, all related to a single
+#     CBS table, from a specific dataset. Since requests to CBS are limited at 10,000
+#     rows (=observations/records), the table_urls consists of the same base url, each ending with "$?SKIP={i}",
+#     where i is an integer with multiples of 10,000, i.e.:
 
-    [
-        "https://opendata.cbs.nl/ODataFeed/odata/83583NED/TypedDataSet?$format=json",
-        "https://opendata.cbs.nl/ODataFeed/odata/83583NED/TypedDataSet?$format=json&$skip=10000"
-        "https://opendata.cbs.nl/ODataFeed/odata/83583NED/TypedDataSet?$format=json&$skip=20000"
-        ...
-        ...
-    ]
+#     [
+#         "https://opendata.cbs.nl/ODataFeed/odata/83583NED/TypedDataSet?$format=json",
+#         "https://opendata.cbs.nl/ODataFeed/odata/83583NED/TypedDataSet?$format=json&$skip=10000"
+#         "https://opendata.cbs.nl/ODataFeed/odata/83583NED/TypedDataSet?$format=json&$skip=20000"
+#         ...
+#         ...
+#     ]
 
-    Parameters
-    ----------
-    table_urls: list of str
-        A list of valid urls of a table from CBS
+#     Parameters
+#     ----------
+#     table_urls: list of str
+#         A list of valid urls of a table from CBS
 
-    Returns
-    -------
-    bag: Dask Bag
-        The values included in table_urls as json type, as a single Dask bag
-    """
-    print("Creating bag")
-    bag = db.from_sequence(table_urls).map(load_from_url)
-    print("Created bag")
-    return bag
+#     Returns
+#     -------
+#     bag: Dask Bag
+#         The values included in table_urls as json type, as a single Dask bag
+#     """
+#     print("Creating bag")
+#     bag = db.from_sequence(table_urls).map(url_to_ndjson)  # ADD FOLDER AS PARAM
+#     # bag = db.from_sequence(table_urls).map(load_from_url)
+#     print("Created bag")
+#     return bag
 
 
-def convert_table_to_parquet(
-    bag, file_name: str, out_dir: Union[str, Path], odata_version: str
-) -> Path:  # (TODO -> IS THERE A FASTER/BETTER WAY??)
-    """Converts a Dask Bag to Parquet files and stores them on disk.
+def convert_ndjsons_to_parquet(
+    files: List[Path], file_name: str, out_dir: Union[Path, str]
+) -> Path:
+    pq_file = Path(f"{out_dir}/{file_name}.parquet")
+    schema = pa_json.read_json(files[0]).schema
+    with pq.ParquetWriter(pq_file, schema) as writer:
+        for f in files:
+            print(f"Processing {f}")
+            table = pa_json.read_json(f)
+            writer.write_table(table)
+            remove(f)
+    return pq_file
 
-    Converts a dask bag holding data from a CBS table to Parquet form
-    and stores it on disk. The bag should be filled by dicts (can be nested)
-    which can be serialized as json.
 
-    The current implementation iterates over each bag partition and dumps
-    it into a json file, then appends all file into a single json file. That
-    json file is then read into a PyArrow table, and finally that table is
-    written as a parquet file to disk.
+# def convert_table_to_parquet(
+#     bag,
+#     file_name: str,
+#     out_dir: Union[str, Path],
+#     odata_version: str
+#     # bag, file_name: str, out_dir: Union[str, Path], odata_version: str
+# ) -> Path:  # (TODO -> IS THERE A FASTER/BETTER WAY??)
+#     """Converts a Dask Bag to Parquet files and stores them on disk.
 
-    Parameters
-    ----------
-    bag: Dask Bag
-        A Bag holding (possibly nested) dicts that can serialized as json
-    file_name: str)
-        The name of the file to store on disk
-    out_dir: str or Path
-        A path to the directory where the file is stored
+#     Converts a dask bag holding data from a CBS table to Parquet form
+#     and stores it on disk. The bag should be filled by dicts (can be nested)
+#     which can be serialized as json.
 
-    Returns
-    -------
-    pq_path: Path
-        The path to the output parquet file
-    """
+#     The current implementation iterates over each bag partition and dumps
+#     it into a json file, then appends all file into a single json file. That
+#     json file is then read into a PyArrow table, and finally that table is
+#     written as a parquet file to disk.
 
-    # create directories to store files
-    out_dir = Path(out_dir)
-    temp_json_dir = out_dir.parent / Path(f"json/{file_name}")
-    create_dir(temp_json_dir)
-    create_dir(out_dir)
+#     Parameters
+#     ----------
+#     bag: Dask Bag
+#         A Bag holding (possibly nested) dicts that can serialized as json
+#     file_name: str)
+#         The name of the file to store on disk
+#     out_dir: str or Path
+#         A path to the directory where the file is stored
 
-    # File path to dump table as ndjson
-    json_path = Path(f"{temp_json_dir}/{file_name}.json")
-    # File path to create as parquet file
-    pq_path = Path(f"{out_dir}/{file_name}.parquet")
+#     Returns
+#     -------
+#     pq_path: Path
+#         The path to the output parquet file
+#     """
 
-    # # Convert bag to parquet #TODO: Check if this method is better then all the file handling below.
-    # # NOTE: this outputs a folder, named (i.e.) "cbs.v3.83583NED_TypedDataSet.parquet", and nests files underneath,
-    # # such as "part.0.parquet", as well as "_metadata" (can be avoided using `write_metadata_file=False`), and "_common_metadata".
-    # bag.to_dataframe().to_parquet(pq_path)
+#     # create directories to store files
+#     out_dir = Path(out_dir)
+#     temp_json_dir = out_dir.parent / Path(f"json/{file_name}")
+#     create_dir(temp_json_dir)
+#     create_dir(out_dir)
 
-    # Dump each bag partition to json file
-    print(f"Dumping bag to textfiles for {file_name}")
-    try:
-        bag.map(ndjson.dumps).to_textfiles(temp_json_dir / "*.json")
-    except TypeError:
-        return None  # TODO: Is this OK???
-    print(f"Finished dumping bag to textfiles for {file_name}")
-    # Get all json file names with path
-    filenames = [f for f in temp_json_dir.glob("*.json")]
-    # Append all ndjsons into a single ndjson file
-    print(f"Starting to concatanate files for {file_name}")
-    with open(json_path, "w+") as json_file:
-        for fn in filenames:
-            with open(Path(fn), "r") as f:
-                json_file.write(f.read())
-            remove(fn)
-    print(f"Concluded concatanating files for {file_name}")
+#     # File path to dump table as ndjson
+#     json_path = Path(f"{temp_json_dir}/{file_name}.json")
+#     # File path to create as parquet file
+#     pq_path = Path(f"{out_dir}/{file_name}.parquet")
 
-    # Create PyArrow table from ndjson file
-    pa_table = pa_json.read_json(json_path)
+#     # # Convert bag to parquet #TODO: Check if this method is better then all the file handling below.
+#     # # NOTE: this outputs a folder, named (i.e.) "cbs.v3.83583NED_TypedDataSet.parquet", and nests files underneath,
+#     # # such as "part.0.parquet", as well as "_metadata" (can be avoided using `write_metadata_file=False`), and "_common_metadata".
+#     # bag.to_dataframe().to_parquet(pq_path)
 
-    # Field names with "." are not allowed when reading the file in BQ
-    new_column_names = [name.replace(".", "_") for name in pa_table.column_names]
-    pa_table = pa_table.rename_columns(new_column_names)
+#     # Dump each bag partition to json file
+#     print(f"Dumping bag to textfiles for {file_name}")
+#     bag.compute()
+#     # try:
+#     #     bag.map(ndjson.dumps).to_textfiles(temp_json_dir / "*.json")
+#     # except TypeError:
+#     #     return None  # TODO: Is this OK???
+#     print(f"Finished dumping bag to textfiles for {file_name}")
+#     # Get all json file names with path
+#     filenames = [f for f in temp_json_dir.glob("*.ndjson")]
+#     # Append all ndjsons into a single ndjson file
+#     print(f"Starting to concatanate files for {file_name}")
+#     with open(json_path, "w+") as json_file:
+#         for fn in filenames:
+#             with open(Path(fn), "r") as f:
+#                 json_file.write(f.read())
+#             remove(fn)
+#     print(f"Concluded concatanating files for {file_name}")
 
-    # Store parquet table #TODO -> set proper data types in parquet file
-    pq.write_table(pa_table, pq_path)
+#     # Create PyArrow table from ndjson file
+#     pa_table = pa_json.read_json(json_path)
 
-    # Remove temp ndjson file
-    remove(json_path)
+#     # Field names with "." are not allowed when reading the file in BQ
+#     new_column_names = [name.replace(".", "_") for name in pa_table.column_names]
+#     pa_table = pa_table.rename_columns(new_column_names)
 
-    return pq_path
+#     # Store parquet table #TODO -> set proper data types in parquet file
+#     pq.write_table(pa_table, pq_path)
+
+#     # Remove temp ndjson file
+#     remove(json_path)
+
+#     return pq_path
 
 
 def set_gcp(config: Config, gcp_env: str, source: str) -> GcpProject:
@@ -1273,13 +1293,15 @@ def generate_table_urls(base_url: str, n_records: int, odata_version: str) -> li
     return table_urls
 
 
-def load_from_url(target_url: str):
-    """Fetch json formatted data from a specific CBS table url.
+def url_to_ndjson(target_url: str, ndjson_folder: Union[Path, str]):
+    """Fetch json formatted data from a specific CBS table url and write each page as n ndjson file.
 
     Parameters
     ----------
     target_url : str
         The url to fetch from
+    ndjson_folder : str or Path
+        The folder to store all output files
 
     Returns
     -------
@@ -1298,8 +1320,17 @@ def load_from_url(target_url: str):
     )  # TODO - Bubble print statement to logging in general and in Prefect
     r = requests.get(target_url).json()
     if r["value"]:
-        return r["value"]
-    else:
+        # Write as ndjson
+        filename = (
+            f"page_{int(target_url.split('skip=')[-1])//10000}.ndjson"
+            if "skip" in target_url
+            else "page_0.ndjson"
+        )
+        path = Path(ndjson_folder) / Path(filename)
+        with open(path, "w+") as f:
+            ndjson.dump(r["value"], f)
+        return path
+    else:  # TODO - is this needed? If so, what should happen here?
         return None
         # raise FileNotFoundError
 
@@ -1326,7 +1357,7 @@ def tables_to_parquet(
     source : str, default='cbs
         The source of the dataset.
     pq_dir : Path or str
-        The directory where the putput Parquet files are stored.
+        The directory where the output Parquet files are stored.
 
     Returns
     -------
@@ -1380,18 +1411,31 @@ def tables_to_parquet(
                 url, table_shape["n_observations"], odata_version
             )
 
-        # Get table as a dask bag
-        table = get_odata(table_urls=table_urls)
+        # create directories to store files
+        pq_dir = Path(pq_dir)
+        ndjson_dir = pq_dir.parent / Path(f"ndjson/{table_name}")
+        create_dir(pq_dir)
+        create_dir(ndjson_dir)
+
+        # Fetch all urls and dump each as ndjson
+        ndjsons_paths = (
+            db.from_sequence(table_urls)
+            .map(url_to_ndjson, ndjson_folder=ndjson_dir)
+            .compute()
+        )
+        # table = get_odata(table_urls=table_urls)
 
         # Convert to parquet
         print(
             f"Starting convert_table_to_parquet for table {table_name}"
         )  # TODO Convert to logging, add pq_dir to INFO
-        pq_path = convert_table_to_parquet(
-            bag=table,
+        pq_path = convert_ndjsons_to_parquet(
+            files=ndjsons_paths,
+            # urls=table_urls,
+            # bag=table,
             file_name=table_name,
             out_dir=pq_dir,
-            odata_version=odata_version,
+            # odata_version=odata_version,
         )
         print()
         print(f"Finished convert_table_to_parquet for table {table_name}")
@@ -1702,7 +1746,7 @@ if __name__ == "__main__":
 
     config = get_config("./statline_bq/config.toml")
     # # Test cbs core dataset, odata_version is v3
-    main("83583NED", config=config, gcp_env="prod", force=True)
+    main("83583NED", config=config, gcp_env="dev", force=True)
     # Test cbs core dataset, odata_version is v4
     # main("83765NED", config=config, gcp_env="dev", force=True)
     # Test IV3 dataset, odata_version is v3


### PR DESCRIPTION
## This PR:
### Conceptually:

* Refactors `tables_to_parquet` to use a small memory footprint, by writing each page containing 10K (or 100K for v4) records to disk, and concatenating them together as a Parquet file using a stream writer. Main changes are:
  * The `Dask Bag` object (representing a single table in a dataset) is created by mapping `url_to_ndjson`  which returns a `Path` to an `ndjson` file instead of the previous `load_from_url` which returned a `dict` object.
  * The concatenating is done using pyarrow's `ParquetWriter`, allowing a single `ndjson` file to be loaded to memory, converted to Parquet, and appended to a different, single file.
* Fixes a bug in the processing of v4 datasets (wrong pagination - per 10k instead of 100k in `utils.generate_table_urls`
* Updates `config` file
* Updates `README` file

### Techincally:
* Adds:
  * `utils.get_schema_cbs()`
* Removes:
  * `utils. get_odata()`
  * `utils.convert_table_to_parquet()`
  * `utils.get_from_meta()`
* Updates:
  * `utils.load_from_url()` into `utils.url_to_ndjson()`
  * `utils. generate_table_urls()` - bug fix
  * Additional functions with minor changes

### Not implemented
1. v4 support for `get_schema_cbs()` - requesting the metadata url returns a 406 error, and should be examined (issue #59 opened). Currently circumventing by using the schema from the first page (considering these are 100k each, and a long format means less columns, the chances of error are much lower)
2. Full translation of `OData` types to `pyarrow` types (issue #61 opened).