### PR TITLE
Remove temp dir

### DIFF
--- a/statline_bq/utils.py
+++ b/statline_bq/utils.py
@@ -1671,7 +1671,7 @@ def main(
         print(f"Processing dataset {id}")
         # print("TEST CHANGES")
         odata_version = check_v4(id=id, third_party=third_party)
-        cbsodata_to_gbq(
+        files_parquet = cbsodata_to_gbq(
             id=id,
             odata_version=odata_version,
             third_party=third_party,
@@ -1683,7 +1683,9 @@ def main(
         print(
             f"Completed dataset {id}"
         )  # TODO - add response from google if possible (some success/failure flag)
-        return None
+        pq_file = Path(files_parquet.pop())
+        local_folder = pq_file.parents[2]
+        return local_folder
 
 
 if __name__ == "__main__":
@@ -1691,7 +1693,7 @@ if __name__ == "__main__":
 
     config = get_config("./statline_bq/config.toml")
     # # Test cbs core dataset, odata_version is v3
-    main("83583NED", config=config, gcp_env="dev", force=True)
+    local_folder = main("83583NED", config=config, gcp_env="dev", force=True)
     # Test cbs core dataset, odata_version is v4
     # main("83765NED", config=config, gcp_env="dev", force=True)
     # Test external dataset, odata_version is v3
@@ -1703,3 +1705,4 @@ if __name__ == "__main__":
     #     gcp_env="dev",
     #     force=True,
     # )
+    print(local_folder)

--- a/statline_bq/utils.py
+++ b/statline_bq/utils.py
@@ -1070,8 +1070,8 @@ def cbsodata_to_gbq(
             credentials=credentials,
         )
 
-    # Remove all local files for this process
-    rmtree(pq_dir.parent)
+    # Remove all local files created for this process
+    rmtree(pq_dir.parents[1])
 
     return files_parquet  # TODO: return bq job ids
 
@@ -1691,9 +1691,9 @@ if __name__ == "__main__":
 
     config = get_config("./statline_bq/config.toml")
     # # Test cbs core dataset, odata_version is v3
-    # main("83583NED", config=config, gcp_env="dev", force=True)
+    main("83583NED", config=config, gcp_env="dev", force=True)
     # Test cbs core dataset, odata_version is v4
-    main("83765NED", config=config, gcp_env="dev", force=True)
+    # main("83765NED", config=config, gcp_env="dev", force=True)
     # Test external dataset, odata_version is v3
     # main(
     #     "40061NED",


### PR DESCRIPTION
This PR:

* Implements a higher level removal of temp folder and end of process:
`local_temp_folder/[source]/[odata_version]/[dataset_id]` is removed, instead of:
`local_temp_folder/[source]/[odata_version]/[dataset_id]/[upload_date]`
* Returns a `Path` item for this folder when running `main` to use for clean up in `nl-open-data` flow implementation.