### PR TITLE
Add cli parameters

### DIFF
--- a/statline_bq/cli.py
+++ b/statline_bq/cli.py
@@ -65,12 +65,6 @@ def upload_datasets(
             )
             return
     gcp_env = gcp_env.lower()
-    # config_envs = {
-    #     "dev": config.gcp.dev,
-    #     "test": config.gcp.test,
-    #     "prod": config.gcp.prod,
-    # }
-    # gcp_project = config_envs.get(gcp_env)
     gcp_project = set_gcp(config, gcp_env, source)
     click.echo("The following datasets will be downloaded from CBS and uploaded into:")
     click.echo("")

--- a/statline_bq/utils.py
+++ b/statline_bq/utils.py
@@ -868,7 +868,7 @@ def cbsodata_to_gbq(
         to use dataderden.cbs.nl as base url (not available in v4 yet).
 
     source: str, default="cbs"
-        The source of the dataset. Currently only "cbs" is relevant.
+        The source of the dataset.
 
     config: Config object
         Config object holding GCP and local paths
@@ -1668,6 +1668,10 @@ def main(
     force: bool = False,
 ) -> Path:
     gcp_env = gcp_env.lower()
+    if third_party and source == "cbs":
+        raise ValueError(
+            "A third-party dataset cannot have 'cbs' as source: please provide correct 'source' parameter"
+        )
     if check_gcp_env(gcp_env):
         print(f"Processing dataset {id}")
         # print("TEST CHANGES")


### PR DESCRIPTION
This PR:

* Adds `source` and `third-party` parameters to the CLI interface, allowing to use the CLI for third-party datasets from statline.
* Uses `utils.set_gcp` in CLI, to conform with new projects arrangement, and future changes.
* Adds a `ValueError` if `third-party` and `source=='cbs'`

Closes #45 