### PR TITLE
Fix data properties

### DIFF
--- a/statline_bq/utils.py
+++ b/statline_bq/utils.py
@@ -1716,58 +1716,36 @@ def main(
 def fix_data_properties(
     id: str,
     source: str = "cbs",
-    third_party: bool = False,
+    # third_party: bool = False,
     config: Box = None,
     gcp_env: str = "dev",
 ):
     gcp = set_gcp(config=config, gcp_env=gcp_env, source=source)
-    odata_version = check_v4(id=id, third_party=third_party)
-    urls = get_urls(id=id, odata_version=odata_version, third_party=third_party)
+    odata_version = "v3"  # only relevant for v3
     pq_dir = create_named_dir(
         id=id, odata_version=odata_version, source=source, config=config
     )
-    url = urls.get("DataProperties")
-    if url:
-        file_name = f"{source}.{odata_version}.{id}_DataProperties"
-        ndjson_dir = pq_dir.parent / "ndjson"
-        create_dir(ndjson_dir)
-        ndjson_path = ndjson_dir / (file_name + ".ndjson")
-        pq_path = pq_dir / (file_name + ".parquet")
-        if odata_version == "v3":
-            url = "?".join((url, "$format=json"))
-        r = requests.get(url).json()
-        with open(ndjson_path, "w+") as f:
-            ndjson.dump(r["value"], f)
-        data_properties_table = pa_json.read_json(ndjson_path)
-        new_column_names = [
-            name.replace(".", "_") for name in data_properties_table.column_names
-        ]
-        data_properties_table = data_properties_table.rename_columns(new_column_names)
-        pq.write_table(data_properties_table, pq_path)
-        # Upload to storage
-        latest_folder = get_latest_folder(
-            gcs_folder=f"{source}/{odata_version}/{id}", gcp=gcp
-        )
-        storage_client = storage.Client(project=gcp.project_id)
-        bucket = storage_client.get_bucket(gcp.bucket)
-        gcs_blob = bucket.blob(latest_folder + "/" + file_name + ".parquet")
-        gcs_blob.upload_from_filename(pq_path)
-        # Link to BQ
-        bq_client = bigquery.Client(project=gcp.project_id)
-        dataset_id = f"{source}_{odata_version}_{id}"
-        dataset_ref = bigquery.DatasetReference(gcp.project_id, dataset_id)
-        table_id = file_name.split(".")[2]
-        table = bigquery.Table(dataset_ref.table(table_id))
-        bq_client.delete_table(table)
-        external_config = bigquery.ExternalConfig("PARQUET")
-        external_config.source_uris = [
-            f"https://storage.cloud.google.com/{gcp.bucket}/{latest_folder}/{file_name}.parquet"
-        ]
-        table.external_data_configuration = external_config
-        bq_client.create_table(table)
-        return pq_dir.parents[3]
-    else:
-        return
+    file_name = f"{source}.{odata_version}.{id}_DataProperties.parquet"
+    after_path = pq_dir / file_name
+    before_path = (
+        pq_dir / f"{source}.{odata_version}.{id}_DataProperties_BEFORE.parquet"
+    )
+    storage_client = storage.Client(project=gcp.project_id)
+    latest_folder = get_latest_folder(
+        gcs_folder=f"{source}/{odata_version}/{id}", gcp=gcp
+    )
+    bucket = storage_client.get_bucket(gcp.bucket)
+    download_blob = bucket.get_blob(latest_folder + "/" + file_name)
+    upload_blob = bucket.get_blob(latest_folder + "/" + file_name)
+    download_blob.download_to_filename(before_path)
+    table = pq.read_table(before_path)
+    new_column_names = [name.replace(".", "_") for name in table.column_names]
+    table = table.rename_columns(new_column_names)
+    pq.write_table(table, after_path)
+    upload_blob.upload_from_filename(after_path)
+    before_path.unlink(missing_ok=True)
+    after_path.unlink(missing_ok=True)
+    return new_column_names
 
 
 if __name__ == "__main__":
@@ -1792,7 +1770,20 @@ if __name__ == "__main__":
     #     force=True,
     # )
     # print(local_folder)
-    fix_data_properties(
-        id="45001NED", source="iv3", third_party=True, config=config, gcp_env="prod"
-    )
-
+    for id in [
+        "45001NED",
+        # "45004NED",
+        # "45005NED",
+        # "45006NED",
+        # "45007NED",
+        # "45008NED",
+        # "45031NED",
+        # "45038NED",
+        # "45042NED",
+        # "45046NED",
+        # "45050NED",
+    ]:
+        new_column_names = fix_data_properties(
+            id=id, source="iv3", config=config, gcp_env="prod"
+        )
+        print(new_column_names)

--- a/statline_bq/utils.py
+++ b/statline_bq/utils.py
@@ -1614,6 +1614,36 @@ def main(
         return local_folder
 
 
+def clean_python_name(s: str, extra_chars: str = ""):
+    """Method to convert string to clean string for use
+    in dataframe column names so that it complies to python 2.x object name standard:
+           (letter|'_')(letter|digit|'_')
+    Based on
+    https://stackoverflow.com/questions/3303312/how-do-i-convert-a-string-to-a-valid-variable-name-in-python
+
+    Parameters
+    ----------
+    s : str
+        string to clean
+    extra_chars : str, optional
+        additional characrters to be replaced by an underscore
+
+    Returns
+    -------
+    s: str
+        clean string
+    """
+    import re
+
+    # Remove leading characters until we find a letter or underscore, and remove trailing spaces
+    s = re.sub("^[^a-zA-Z_]+", "", s.strip())
+
+    # Replace invalid characters with underscores
+    s = re.sub("[^0-9a-zA-Z_]" + extra_chars, "_", s)
+
+    return s
+
+
 def fix_data_properties(
     id: str,
     source: str = "cbs",
@@ -1640,7 +1670,7 @@ def fix_data_properties(
     upload_blob = bucket.get_blob(latest_folder + "/" + file_name)
     download_blob.download_to_filename(before_path)
     table = pq.read_table(before_path)
-    new_column_names = [name.replace(".", "_") for name in table.column_names]
+    new_column_names = [clean_python_name(name, ".") for name in table.column_names]
     table = table.rename_columns(new_column_names)
     pq.write_table(table, after_path)
     upload_blob.upload_from_filename(after_path)

--- a/statline_bq/utils.py
+++ b/statline_bq/utils.py
@@ -422,105 +422,6 @@ def create_dir(path: Path) -> Path:
         return None
 
 
-# def get_dataset_description(urls: dict, odata_version: str) -> str:
-#     """Gets a CBS dataset description text.
-
-#     Wrapper function to call the correct version function which in turn gets
-#     the dataset description according to the odata version: "v3" or "v4".
-
-#     Parameters
-#     ----------
-#     urls: dict
-#         Dictionary holding urls of the dataset from CBS.
-#         NOTE: urls["Properties"] (for v4) or urls["TableInfos"] (for v3)
-#         must be present in order to access the dataset description.
-
-#     odata_version: str
-#         version of the odata for this dataset - must be either "v3" or "v4".
-
-#     Returns
-#     -------
-#     description: str
-#         The description of the dataset from CBS.
-
-#     Raises
-#     ------
-#     ValueError
-#         If odata_version is not "v3" or "v4"
-
-#     Examples
-#     --------
-#     >>> from statline_bq.utils import get_dataset_description
-#     >>> urls = {
-#     ...         "TableInfos": "https://opendata.cbs.nl/ODataFeed/odata/83583NED/TableInfos",
-#     ...         "UntypedDataSet": "https://opendata.cbs.nl/ODataFeed/odata/83583NED/UntypedDataSet"
-#     ...         }
-#     >>> odata_version = "v3"
-#     >>> description_text = get_dataset_description(urls, odata_version=odata_version)
-#     >>> description_text
-#     #Text describing the dataset will print
-#     """
-
-#     if odata_version.lower() == "v4":
-#         description = get_dataset_description_v4(urls["Properties"])
-#     elif odata_version.lower() == "v3":
-#         description = get_dataset_description_v3(urls["TableInfos"])
-#     else:
-#         raise ValueError("odata version must be either 'v3' or 'v4'")
-#     return description
-
-
-# def get_dataset_description_v3(url_table_infos: str) -> str:
-#     """Gets the description of a v3 odata dataset from CBS provided in url_table_infos.
-
-#     Usually wrapped in `get_dataset_description()`, and it is better practice
-#     to call it wrapped to allow for both "v3" and "v4" functionality.
-
-#     Parameters
-#     ----------
-#     url_table_infos: str
-#         The url for a dataset's "TableInfos" table as string.
-
-#     Returns
-#     -------
-#     description: str
-#         A string with the dataset's description
-#     """
-
-#     # Get JSON format of data set.
-#     url_table_infos = "?".join((url_table_infos, "$format=json"))
-
-#     data_info = requests.get(url_table_infos).json()  # Is of type dict()
-
-#     data_info_values = data_info["value"]  # Is of type list
-
-#     # Get short description as text
-#     description = data_info_values[0]["ShortDescription"]
-
-#     return description
-
-
-# def get_dataset_description_v4(url_table_properties: str) -> str:
-#     """Gets table description of a table in CBS odata V4.
-
-#     Usually wrapped in `get_dataset_description()`, and it is better practice
-#     to call it wrapped to allow for both "v3" and "v4" functionality.
-
-#     Parameters
-#     ----------
-#     url_table_properties: str
-#         The url for a dataset's "Properties" table as string.
-
-#     Returns
-#     -------
-#     description: str
-#         A string with the dataset's description
-#     """
-
-#     r = requests.get(url_table_properties).json()
-#     return r["Description"]
-
-
 def get_column_descriptions(urls: dict, odata_version: str) -> dict:
     """Gets the column descriptions from CBS.
 
@@ -1771,19 +1672,20 @@ if __name__ == "__main__":
     # )
     # print(local_folder)
     for id in [
-        "45001NED",
-        # "45004NED",
-        # "45005NED",
-        # "45006NED",
-        # "45007NED",
-        # "45008NED",
-        # "45031NED",
-        # "45038NED",
-        # "45042NED",
-        # "45046NED",
-        # "45050NED",
+        "81008ned",
+        "81498ned",
+        "82000NED",
+        "82496NED",
+        "82949NED",
+        "83287NED",
+        "83553NED",
+        "83859NED",
+        "84378NED",
+        "84721NED",
+        "84929NED",
+        "70739ned",
     ]:
         new_column_names = fix_data_properties(
-            id=id, source="iv3", config=config, gcp_env="prod"
+            id=id, source="cbs", config=config, gcp_env="prod"
         )
         print(new_column_names)

--- a/statline_bq/utils.py
+++ b/statline_bq/utils.py
@@ -1014,6 +1014,18 @@ def cbsodata_to_gbq(
         source=source,
         pq_dir=pq_dir,
     )
+    # DataProperties table contains "." in field names which is not allowed in linked BQ tables
+    data_properties_pq = next(
+        (x for x in files_parquet if "DataProperties" in str(x)), None
+    )
+    if data_properties_pq:
+        data_properties_table = pq.read_table(data_properties_pq)
+        new_column_names = [
+            name.replace(".", "_") for name in data_properties_table.column_names
+        ]
+        data_properties_table = data_properties_table.rename_columns(new_column_names)
+        pq.write_table(data_properties_table, data_properties_pq)
+
     # Get columns' descriptions from CBS
     col_descriptions = get_column_descriptions(urls, odata_version=odata_version)
     # Write column descriptions to json file and store in dataset directory with parquet tables
@@ -1706,17 +1718,17 @@ if __name__ == "__main__":
 
     config = get_config("./statline_bq/config.toml")
     # # Test cbs core dataset, odata_version is v3
-    local_folder = main("83583NED", config=config, gcp_env="dev", force=True)
+    # local_folder = main("83583NED", config=config, gcp_env="dev", force=True)
     # # Test skipping a dataset, odata_version is v3
     # local_folder = main("83583NED", config=config, gcp_env="dev", force=False)
     # Test cbs core dataset, odata_version is v3, contaiing empty url (CategoryGroups)
     # local_folder = main("84799NED", config=config, gcp_env="dev", force=True)
     # Test cbs core dataset, odata_version is v4
-    # main("83765NED", config=config, gcp_env="dev", force=True)
+    main("83765NED", config=config, gcp_env="dev", force=True)
     # Test external dataset, odata_version is v3
     # main(
-    #     "40061NED",
-    #     source="mlz",
+    #     "45012NED",
+    #     source="iv3",
     #     third_party=True,
     #     config=config,
     #     gcp_env="dev",


### PR DESCRIPTION
This PR:

* Adds a step to the processing of datasets (`main`), where the `DataProperties` table column names are checked for any "." and replaced with "_". Ideally this would be done for all tables, but since there is no simple way to do this without loading the whole table to memory, this focuses on where this problem has actually occurred.
* Adds a function `fix_data_properties()` that:
  * downloads the `DataProperties` table from the latest GCS folder
  * renames the columns
  * uploads the renamed file to the same location, overwriting the exisitng file.

  thereby fixing the issue without having to re-upload the whole dataset.