### PR TITLE
Logging

### DIFF
--- a/statline_bq/log.py
+++ b/statline_bq/log.py
@@ -1,4 +1,4 @@
-# Logger decorator to log general execution of functions.
+# # Logger decorator to log general execution of functions.
 # Based on https://medium.com/swlh/add-log-decorators-to-your-python-project-84094f832181
 from pathlib import Path
 import sys
@@ -8,8 +8,19 @@ import logging.config
 
 import toml
 
+LOG_DIR = Path.home() / ".statline-bq/logs"
 LOGGING_CONF_FILE = Path(__file__).parent / "logging_conf.toml"
-logging.config.dictConfig(toml.load(LOGGING_CONF_FILE))
+
+log_conf = toml.load(LOGGING_CONF_FILE)
+for handler, handler_conf in log_conf.get("handlers").items():
+    if "File" in handler_conf.get("class"):
+        filepath = LOG_DIR / handler_conf.get("filename")
+        handler_conf["filename"] = str(filepath)
+
+if not (LOG_DIR.exists() and LOG_DIR.is_dir()):
+    LOG_DIR.mkdir(parents=True)
+
+logging.config.dictConfig(log_conf)
 
 
 def logdec(func):

--- a/statline_bq/log.py
+++ b/statline_bq/log.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import functools
+import logging
+import logging.config
+
+import toml
+
+LOGGING_CONF_FILE = Path(__file__).parent / "logging_conf.toml"
+logging.config.dictConfig(toml.load(LOGGING_CONF_FILE))
+
+
+def logdec(func):
+    @functools.wraps(func)
+    def log(*args, **kwargs):
+        logger = logging.getLogger(func.__module__)
+        print(func.__module__)
+        result = func(*args, **kwargs)
+        return result
+
+    return log

--- a/statline_bq/log.py
+++ b/statline_bq/log.py
@@ -1,5 +1,4 @@
-# # Logger decorator to log general execution of functions.
-# Based on https://medium.com/swlh/add-log-decorators-to-your-python-project-84094f832181
+# Logging module, reading a logging configuration toml file, defining the logs output folder and creating a logging decorator that can be applied to any function.
 from pathlib import Path
 import sys
 import functools
@@ -24,6 +23,25 @@ logging.config.dictConfig(log_conf)
 
 
 def logdec(func):
+    """A logging decorator wrapping a function with a standard logging mechanism.
+
+    This decorator wraps a function with a standard logging mechanism, providing the following functionalities:
+    * Logs the calling of the function and the parameters passed to it when called.
+    * If no exception is raised during the function run - returns the result and logs the succesful completion (not the result).
+    * If an exception is raised - logs the exception and returns None.
+
+    Based on https://medium.com/swlh/add-log-decorators-to-your-python-project-84094f832181
+
+    Parameters
+    ----------
+    func : the function to be wrapped
+
+    Returns
+    -------
+    result or None
+        The result of the function if no exception was raised, None otherwise
+    """
+
     @functools.wraps(func)
     def logged(*args, **kwargs):
         # Create a list of the positional arguments passed to function

--- a/statline_bq/log.py
+++ b/statline_bq/log.py
@@ -1,6 +1,5 @@
 # Logging module, reading a logging configuration toml file, defining the logs output folder and creating a logging decorator that can be applied to any function.
 from pathlib import Path
-import sys
 import functools
 import logging
 import logging.config
@@ -60,9 +59,9 @@ def logdec(func):
             result = func(*args, **kwargs)
             logger.info(f"Succesfully finished function {func.__name__}")
             return result
-        except:
+        except Exception as e:
             # Log exception if occurs in function
-            logger.error(f"Exception in {func.__name__}: {str(sys.exc_info()[1])}")
-            return None
+            logger.exception(f"Exception in {func.__name__}: {e}")
+            raise e
 
     return logged

--- a/statline_bq/log.py
+++ b/statline_bq/log.py
@@ -1,4 +1,7 @@
+# Logger decorator to log general execution of functions.
+# Based on https://medium.com/swlh/add-log-decorators-to-your-python-project-84094f832181
 from pathlib import Path
+import sys
 import functools
 import logging
 import logging.config
@@ -11,10 +14,26 @@ logging.config.dictConfig(toml.load(LOGGING_CONF_FILE))
 
 def logdec(func):
     @functools.wraps(func)
-    def log(*args, **kwargs):
+    def logged(*args, **kwargs):
+        # Create a list of the positional arguments passed to function
+        args_passed_in_function = [repr(a) for a in args]
+        # Create a list of the keyword arguments
+        kwargs_passed_in_function = [f"{k}={v!r}" for k, v in kwargs.items()]
+        # The lists of positional and keyword arguments is joined together to form final string
+        formatted_arguments = ", ".join(
+            args_passed_in_function + kwargs_passed_in_function
+        )
         logger = logging.getLogger(func.__module__)
-        print(func.__module__)
-        result = func(*args, **kwargs)
-        return result
+        logger.info(
+            f"Starting function {func.__name__} with arguments: ({formatted_arguments})"
+        )
+        try:
+            result = func(*args, **kwargs)
+            logger.info(f"Succesfully finished function {func.__name__}")
+            return result
+        except:
+            # Log exception if occurs in function
+            logger.error(f"Exception in {func.__name__}: {str(sys.exc_info()[1])}")
+            return None
 
-    return log
+    return logged

--- a/statline_bq/logging_conf.toml
+++ b/statline_bq/logging_conf.toml
@@ -12,11 +12,14 @@ level="INFO"
 formatter="standard"
 stream="ext://sys.stdout"
 
-# [handlers.file]
-# class="logging.FileHandler"
-# level="WARNING"
-# formatter="standard"
+[handlers.file]
+class="logging.handlers.RotatingFileHandler"
+level="WARNING"
+formatter="standard"
+filename="statlinq_bq.log"
+maxBytes=2097152  # 2MB
+backupCount=5
 
 [root]
 level="INFO"
-handlers=["console"]
+handlers=["console", "file"]

--- a/statline_bq/logging_conf.toml
+++ b/statline_bq/logging_conf.toml
@@ -3,7 +3,7 @@ disable_existing_loggers=false
 
 [formatters]
 [formatters.standard]
-format="%(asctime)s %(name)s - %(levelname)s:%(message)s"
+format="%(asctime)s - %(name)s - %(levelname)s: %(message)s"
 
 [handlers]
 [handlers.console]
@@ -11,6 +11,11 @@ class="logging.StreamHandler"
 level="INFO"
 formatter="standard"
 stream="ext://sys.stdout"
+
+# [handlers.file]
+# class="logging.FileHandler"
+# level="WARNING"
+# formatter="standard"
 
 [root]
 level="INFO"

--- a/statline_bq/utils.py
+++ b/statline_bq/utils.py
@@ -334,7 +334,6 @@ def get_metadata_gcp(
         return meta
     except AttributeError:
         # TODO: How to manage warnings in a the log decorator?
-        pass
         # logger.warning(
         #     f"No metadata was found in GCP {gcp.project_id} for {source}_{odata_version}_{id}"
         # )

--- a/statline_bq/utils.py
+++ b/statline_bq/utils.py
@@ -3,13 +3,13 @@ from os import remove, listdir, PathLike
 from pathlib import Path
 import requests
 import json
-import toml
 from datetime import datetime
 from shutil import rmtree
 from tempfile import gettempdir
 import xml.etree.ElementTree as ET
-import logging
-import logging.config
+
+# import logging
+# import logging.config
 
 import ndjson
 import dask.bag as db
@@ -18,15 +18,12 @@ from pyarrow import json as pa_json
 import pyarrow.parquet as pq
 from google.cloud import storage
 from google.cloud import bigquery
-from google.api_core import exceptions
+
+# from google.api_core import exceptions
 from google.oauth2.credentials import Credentials
 from box import Box
 
 from statline_bq.log import logdec
-
-# LOGGING_CONF_FILE = Path(__file__).parent / "logging_conf.toml"
-# logging.config.dictConfig(toml.load(LOGGING_CONF_FILE))
-# logger = logging.getLogger(__name__)
 
 
 @logdec
@@ -51,12 +48,12 @@ def check_gcp_env(gcp_env: str, options: List[str] = ["dev", "test", "prod"]) ->
         If gcp_env is not one of options
     """
     if gcp_env not in options:
-        logging.error(f"Please set gcp_env to be one of {options}")
-        # raise ValueError(f"gcp_env must be one of {options}")
+        raise ValueError(f"gcp_env must be one of {options}")
     else:
         return True
 
 
+@logdec
 def check_v4(id: str, third_party: bool = False) -> str:
     """Checks whether a certain CBS table exists as OData Version "v4".
 
@@ -93,6 +90,7 @@ def check_v4(id: str, third_party: bool = False) -> str:
     return odata_version
 
 
+@logdec
 def get_metadata_cbs(id: str, third_party: bool, odata_version: str) -> dict:
     """Retrieves a dataset's metadata from cbs.
 
@@ -151,6 +149,7 @@ def get_metadata_cbs(id: str, third_party: bool, odata_version: str) -> dict:
     return meta
 
 
+@logdec
 def get_main_table_shape(metadata: dict) -> dict:
     """Reads into a CBS dataset metadata and returns the main table's shape as a dict.
 
@@ -177,6 +176,7 @@ def get_main_table_shape(metadata: dict) -> dict:
     return main_table_shape
 
 
+@logdec
 def get_schema_cbs(metadata_url, odata_version) -> pa.Schema:
     """Returns a pyarrow.Schema for the main table of a cbs dataset given its base metadata url.
 
@@ -247,6 +247,7 @@ def get_schema_cbs(metadata_url, odata_version) -> pa.Schema:
     return schema
 
 
+@logdec
 def get_latest_folder(
     gcs_folder: str, gcp: Box, credentials: Credentials = None
 ) -> Union[str, None]:
@@ -293,6 +294,7 @@ def get_latest_folder(
     return folder
 
 
+@logdec
 def get_metadata_gcp(
     id: str, source: str, odata_version: str, gcp: Box, credentials: Credentials = None,
 ) -> Union[dict, None]:
@@ -331,12 +333,15 @@ def get_metadata_gcp(
         meta = json.loads(blob.download_as_string())
         return meta
     except AttributeError:
-        logging.warning(
-            f"No metadata was found in GCP {gcp.project_id} for {source}_{odata_version}_{id}"
-        )
+        # TODO: How to manage warnings in a the log decorator?
+        pass
+        # logger.warning(
+        #     f"No metadata was found in GCP {gcp.project_id} for {source}_{odata_version}_{id}"
+        # )
         return None
 
 
+@logdec
 def dict_to_json_file(
     id: str,
     dict: dict,
@@ -383,6 +388,7 @@ def dict_to_json_file(
     return json_file
 
 
+@logdec
 def get_gcp_modified(gcp_meta: dict, force: bool = False) -> Union[str, None]:
     if not force:
         try:
@@ -394,6 +400,7 @@ def get_gcp_modified(gcp_meta: dict, force: bool = False) -> Union[str, None]:
     return gcp_modified
 
 
+@logdec
 def skip_dataset(cbs_modified: str, gcp_modified: str, force: bool) -> bool:
     if (cbs_modified is None or cbs_modified == gcp_modified) and (not force):
         return True
@@ -401,6 +408,7 @@ def skip_dataset(cbs_modified: str, gcp_modified: str, force: bool) -> bool:
         return False
 
 
+@logdec
 def create_dir(path: Path) -> Path:
     """Checks whether a path exists and is a directory, and creates it if not.
 
@@ -415,16 +423,18 @@ def create_dir(path: Path) -> Path:
         The same input path, to new or existing directory.
     """
 
-    try:
-        path = Path(path)
-        if not (path.exists() and path.is_dir()):
-            path.mkdir(parents=True)
-        return path
-    except TypeError as error:
-        logging.exception(f"Error trying to find {path}: {error!s}")
-        return None
+    # try:
+    path = Path(path)
+    if not (path.exists() and path.is_dir()):
+        path.mkdir(parents=True)
+    return path
+    #
+    # except TypeError as error:
+    #     logger.exception(f"Error trying to find {path}: {error!s}")
+    #     return None
 
 
+@logdec
 def get_column_descriptions(urls: dict, odata_version: str) -> dict:
     """Gets the column descriptions from CBS.
 
@@ -462,6 +472,7 @@ def get_column_descriptions(urls: dict, odata_version: str) -> dict:
     return column_descriptions
 
 
+@logdec
 def get_column_descriptions_v3(url_data_properties: str) -> dict:
     """Gets the column descriptions for the TypedDataSet of a CBS dataset V3
 
@@ -492,6 +503,7 @@ def get_column_descriptions_v3(url_data_properties: str) -> dict:
     return col_desc
 
 
+@logdec
 def convert_ndjsons_to_parquet(
     files: List[Path], file_name: str, out_dir: Union[Path, str], schema: pa.Schema
 ) -> Path:
@@ -501,13 +513,14 @@ def convert_ndjsons_to_parquet(
     with pq.ParquetWriter(pq_file, schema) as writer:
         parse_options = pa_json.ParseOptions(explicit_schema=schema)
         for f in files:
-            logging.info(f"Processing {f}")
+            # logger.info(f"Processing {f}")
             table = pa_json.read_json(f, parse_options=parse_options)
             writer.write_table(table)
             remove(f)
     return pq_file
 
 
+@logdec
 def set_gcp(config: Box, gcp_env: str, source: str) -> Box:
     """Sets the desired GCP donciguration
 
@@ -540,6 +553,7 @@ def set_gcp(config: Box, gcp_env: str, source: str) -> Box:
     return config_envs[gcp_env][source] if gcp_env == "prod" else config_envs[gcp_env]
 
 
+@logdec
 def upload_to_gcs(
     dir: Path,
     source: str = "cbs",
@@ -601,6 +615,7 @@ def upload_to_gcs(
     return gcs_folder  # TODO: return job id, if possible
 
 
+@logdec
 def get_file_names(paths: Iterable[Union[str, PathLike]]) -> list:
     """Gets the filenames from an iterable of Path-like objects
 
@@ -635,6 +650,7 @@ def get_file_names(paths: Iterable[Union[str, PathLike]]) -> list:
     return file_names
 
 
+@logdec
 def bq_update_main_table_col_descriptions(
     dataset_ref: str,
     descriptions: dict,
@@ -676,15 +692,15 @@ def bq_update_main_table_col_descriptions(
             main_table_id = table.table_id
             break
 
-    try:
-        # write as standard SQL format
-        main_table_id = dataset_ref.dataset_id + "." + main_table_id
-        main_table = client.get_table(main_table_id)
-    except UnboundLocalError as e:
-        logging.exception(
-            f"No table located with 'TypedDataset' in its name for dataset {dataset_ref}: {e}"
-        )
-        return None
+    # try:
+    # write as standard SQL format
+    main_table_id = dataset_ref.dataset_id + "." + main_table_id
+    main_table = client.get_table(main_table_id)
+    # except UnboundLocalError as e:
+    # logger.exception(
+    #     f"No table located with 'TypedDataset' in its name for dataset {dataset_ref}: {e}"
+    # )
+    return None
 
     # Create SchemaField for column description
     new_schema = []
@@ -700,6 +716,7 @@ def bq_update_main_table_col_descriptions(
     return table
 
 
+@logdec
 def get_col_descs_from_gcs(
     id: str,
     source: str = "cbs",
@@ -747,6 +764,7 @@ def get_col_descs_from_gcs(
     return col_desc
 
 
+@logdec
 def cbsodata_to_gbq(
     id: str,
     odata_version: str,
@@ -894,12 +912,13 @@ def cbsodata_to_gbq(
     # Skip all process if modified date is the same in GCP and source (and Force is set to False)
     if skip_dataset(cbs_modified, gcp_modified, force):
         # if (cbs_modified is None or cbs_modified == gcp_modified) and (not force):
-        logging.info(cbs_modified)
-        logging.info(
-            f"Skipping dataset {id} because the same dataset exists on GCP, with the same 'Modified' date"
-        )
-        logging.info(f"Dataset {id} source last modified: {cbs_modified}")
-        logging.info(f"Dataset {id} gcp last modified: {gcp_modified}")
+        # TODO: Lost info
+        # logger.info(cbs_modified)
+        # logger.info(
+        #     f"Skipping dataset {id} because the same dataset exists on GCP, with the same 'Modified' date"
+        # )
+        # logger.info(f"Dataset {id} source last modified: {cbs_modified}")
+        # logger.info(f"Dataset {id} gcp last modified: {gcp_modified}")
         return None
 
     # Create directory to store parquest files locally
@@ -997,6 +1016,7 @@ def cbsodata_to_gbq(
     return files_parquet  # TODO: return bq job ids
 
 
+@logdec
 def get_urls(
     id: str, odata_version: str, third_party: bool = False
 ) -> dict:  # TODO: Rename to get_dataset_urls (contrast with get_table_urls)
@@ -1056,6 +1076,7 @@ def get_urls(
     return urls
 
 
+@logdec
 def create_named_dir(
     id: str, odata_version: str, source: str = "cbs", config: Box = None
 ) -> Path:
@@ -1113,6 +1134,7 @@ def create_named_dir(
     return path_to_named_dir
 
 
+@logdec
 def generate_table_urls(base_url: str, n_records: int, odata_version: str) -> list:
     """Creates a list of urls for parallel fetching.
 
@@ -1155,6 +1177,7 @@ def generate_table_urls(base_url: str, n_records: int, odata_version: str) -> li
     return table_urls
 
 
+@logdec
 def url_to_ndjson(target_url: str, ndjson_folder: Union[Path, str]):
     """Fetch json formatted data from a specific CBS table url and write each page as n ndjson file.
 
@@ -1176,9 +1199,10 @@ def url_to_ndjson(target_url: str, ndjson_folder: Union[Path, str]):
         if no values exist in the url
     """
 
-    logging.info(
-        f"load_from_url: url = {target_url}"
-    )  # TODO - Bubble print statement to logging in general and in Prefect
+    # TODO: Lost info
+    # logger.info(
+    #     f"load_from_url: url = {target_url}"
+    # )  # TODO - Bubble print statement to logging in general and in Prefect
     r = requests.get(target_url).json()
     if r["value"]:
         # Write as ndjson
@@ -1195,6 +1219,7 @@ def url_to_ndjson(target_url: str, ndjson_folder: Union[Path, str]):
         return None
 
 
+@logdec
 def tables_to_parquet(
     id: str,
     third_party: bool,
@@ -1292,9 +1317,9 @@ def tables_to_parquet(
         # Some urls (i.e. 84799NED_CategoryGroups) are actually empty. These will be computed to None, and skipped here
         if any(ndjsons_paths):
             # Convert to parquet
-            logging.info(
-                f"Starting convert_ndjson_to_parquet for table {table_name}"
-            )  # TODO Convert to logging, add pq_dir to INFO
+            # logger.info(
+            #     f"Starting convert_ndjson_to_parquet for table {table_name}"
+            # )
             pq_path = convert_ndjsons_to_parquet(
                 files=ndjsons_paths,
                 # urls=table_urls,
@@ -1304,7 +1329,7 @@ def tables_to_parquet(
                 schema=schema
                 # odata_version=odata_version,
             )
-            logging.info(f"Finished convert_ndjson_to_parquet for table {table_name}")
+            # logger.info(f"Finished convert_ndjson_to_parquet for table {table_name}")
         # Add path of file to set
         if pq_path:
             files_parquet.add(pq_path)
@@ -1312,6 +1337,7 @@ def tables_to_parquet(
     return files_parquet
 
 
+@logdec
 def create_bq_dataset(
     id: str,
     source: str = "cbs",
@@ -1360,17 +1386,18 @@ def create_bq_dataset(
     # Send the dataset to the API for creation, with an explicit timeout.
     # Raises google.api_core.exceptions.Conflict if the Dataset already
     # exists within the project.
-    try:
-        dataset = client.create_dataset(dataset, timeout=30)  # Make an API request.
-        logging.info(f"Created dataset {client.project}.{dataset.dataset_id}")
-    except exceptions.Conflict as e:
-        logging.exception(
-            f"Dataset {client.project}.{dataset.dataset_id} already exists: {e}"
-        )
-    finally:
-        return dataset.dataset_id
+    # try:
+    dataset = client.create_dataset(dataset, timeout=30)  # Make an API request.
+    # logger.info(f"Created dataset {client.project}.{dataset.dataset_id}")
+    # except exceptions.Conflict as e:
+    # logger.exception(
+    # f"Dataset {client.project}.{dataset.dataset_id} already exists: {e}"
+    # )
+    # finally:
+    return dataset.dataset_id
 
 
+@logdec
 def check_bq_dataset(
     id: str,
     source: str,
@@ -1399,15 +1426,16 @@ def check_bq_dataset(
 
     dataset_id = f"{source}_{odata_version}_{id}"
 
-    try:
-        client.get_dataset(dataset_id)  # Make an API request.
-        # logging.info(f"Dataset {dataset_id} already exists")
-        return True
-    except exceptions.NotFound as e:
-        logging.exception(f"Dataset {dataset_id} is not found: {e}")
-        return False
+    # try:
+    client.get_dataset(dataset_id)  # Make an API request.
+    # logger.info(f"Dataset {dataset_id} already exists")
+    return True
+    # except exceptions.NotFound as e:
+    #     logger.exception(f"Dataset {dataset_id} is not found: {e}")
+    #     return False
 
 
+@logdec
 def delete_bq_dataset(
     id: str,
     source: str = "cbs",
@@ -1447,6 +1475,7 @@ def delete_bq_dataset(
     return None
 
 
+@logdec
 def gcs_to_gbq(
     id: str,
     source: str = "cbs",
@@ -1580,6 +1609,7 @@ def gcs_to_gbq(
     return dataset_ref  # TODO Return job id??
 
 
+@logdec
 def main(
     id: str,
     source: str = "cbs",
@@ -1594,8 +1624,8 @@ def main(
             "A third-party dataset cannot have 'cbs' as source: please provide correct 'source' parameter"
         )
     if check_gcp_env(gcp_env):
-        logging.info(f"Processing dataset {id}")
-        # logging.info("TEST CHANGES")
+        # logger.info(f"Processing dataset {id}")
+        # logger.info("TEST CHANGES")
         odata_version = check_v4(id=id, third_party=third_party)
         files_parquet = cbsodata_to_gbq(
             id=id,
@@ -1606,9 +1636,9 @@ def main(
             gcp_env=gcp_env,
             force=force,
         )
-        logging.info(
-            f"Completed dataset {id}"
-        )  # TODO - add response from google if possible (some success/failure flag)
+        # logger.info(
+        #     f"Completed dataset {id}"
+        # )  # TODO - add response from google if possible (some success/failure flag)
         if files_parquet:
             pq_file = Path(files_parquet.pop())
             local_folder = pq_file.parents[2]
@@ -1617,6 +1647,7 @@ def main(
         return local_folder
 
 
+@logdec
 def clean_python_name(s: str, extra_chars: str = ""):
     """Method to convert string to clean string for use
     in dataframe column names so that it complies to python 2.x object name standard:
@@ -1647,6 +1678,7 @@ def clean_python_name(s: str, extra_chars: str = ""):
     return s
 
 
+@logdec
 def fix_data_properties(
     id: str,
     source: str = "cbs",
@@ -1687,7 +1719,7 @@ if __name__ == "__main__":
 
     config = get_config("./statline_bq/config.toml")
     # # Test cbs core dataset, odata_version is v3
-    local_folder = main("83583NED", config=config, gcp_env="A", force=True)
+    local_folder = main("83583NED", config=config, gcp_env="dev", force=True)
     # # Test skipping a dataset, odata_version is v3
     # local_folder = main("83583NED", config=config, gcp_env="dev", force=False)
     # Test cbs core dataset, odata_version is v3, contaiing empty url (CategoryGroups)
@@ -1704,21 +1736,21 @@ if __name__ == "__main__":
     #     force=True,
     # )
     # print(local_folder)
-    for id in [
-        "81008ned",
-        "81498ned",
-        "82000NED",
-        "82496NED",
-        "82949NED",
-        "83287NED",
-        "83553NED",
-        "83859NED",
-        "84378NED",
-        "84721NED",
-        "84929NED",
-        "70739ned",
-    ]:
-        new_column_names = fix_data_properties(
-            id=id, source="cbs", config=config, gcp_env="prod"
-        )
-        print(new_column_names)
+    # for id in [
+    #     "81008ned",
+    #     "81498ned",
+    #     "82000NED",
+    #     "82496NED",
+    #     "82949NED",
+    #     "83287NED",
+    #     "83553NED",
+    #     "83859NED",
+    #     "84378NED",
+    #     "84721NED",
+    #     "84929NED",
+    #     "70739ned",
+    # ]:
+    #     new_column_names = fix_data_properties(
+    #         id=id, source="cbs", config=config, gcp_env="prod"
+    #     )
+    #     print(new_column_names)


### PR DESCRIPTION
This PR adds standard logging to the library, through the implementation of a general logging decorator + a per-module specific logger.

The implementation is done in 3 files:

- `logging_conf.toml` is where all logging configurations are provided - we can add and define formatters, handlers and loggers there.
  - Currently a single `logger` is defined: `root`, with 2 `handlers`:
    - `file` - a `RotatingFileHandler` set to `WARNING` level (although as it currently stands, we only use `INFO` or `ERROR` in practice)
    - `console`- a `StreamHandler` set to `INFO` level
  - Both `handlers` use the same `formatter`: `standard`
- `log.py` - where the decorator is defined
  - It is also where the logs folder is defined and created - is there a better best practice for this?
- `utils.py`:
  - All functions are currently decorated
  - Additionally, an identically named `logger` is defined within that file, to add additional, non-generic log events.

Closes #67 
___________

@dkapitan 
Changes from our last discussion in the issue:
- I realised that adding non-generic logging is actually trivial! By calling a logger with the module name, after importing the `logdec` from `statline_bq.log` we can use the same logger, named `statline_bq.utils`, which was already configured in `log.py`, and simply use it to add specific logging events wherever we like. Python is awsome.
- I deliberately rely on the `None` value returned by the decorator in case of an `exception`. That, plus ducktyping, replaces some cases which were previously handled by `try... except...` blocks, returning `None` or `False`. See for example `check_bq_dataset`, defined in line 1399, called in line 1550. My concern here is that I am relying on behaviour that is defined outside of the function. Let me know what you think.